### PR TITLE
Make npm installable(easier)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,19 @@
 - base64 codec function
 - ajax integrated base64 decoding functionality
 
-### Sample ###
+## Usage ##
 
+### In Browser ###
+~~~html
+<script src="jquery.base64.js"></script>
+~~~
+
+### npm ###
+~~~sh
+npm install --save tamakiii/jquery.base64#v0.1.0
+~~~
+
+## Sample ##
 
 ```javascript
 // encode/decode

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ### npm ###
 ~~~sh
-npm install --save tamakiii/jquery.base64#v0.1.0
+npm install --save tamakiii/jquery.base64#v0.0.1
 ~~~
 
 ## Sample ##

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ### npm ###
 ~~~sh
-npm install --save tamakiii/jquery.base64#v0.1.0
+npm install --save yatt/jquery.base64#v0.1.0
 ~~~
 
 ## Sample ##

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tamakiii/jquery.base64.git"
+    "url": "git+https://github.com/yatt/jquery.base64.git"
   },
   "keywords": [
     "jquery", "base64", "javascript"
@@ -19,7 +19,7 @@
   "author": "yatt",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/tamakiii/jquery.base64/issues"
+    "url": "https://github.com/yatt/jquery.base64/issues"
   },
-  "homepage": "https://github.com/tamakiii/jquery.base64#readme"
+  "homepage": "https://github.com/yatt/jquery.base64#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery.base64",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "jquery plugin supports base64 codec and ajax integrated base64 decoding functionality",
   "main": "jquery.base64.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "jquery.base64",
+  "version": "0.1.0",
+  "description": "jquery plugin supports base64 codec and ajax integrated base64 decoding functionality",
+  "main": "jquery.base64.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tamakiii/jquery.base64.git"
+  },
+  "keywords": [
+    "jquery", "base64", "javascript"
+  ],
+  "author": "yatt",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/tamakiii/jquery.base64/issues"
+  },
+  "homepage": "https://github.com/tamakiii/jquery.base64#readme"
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "jquery", "base64", "javascript"
   ],
   "author": "yatt",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/tamakiii/jquery.base64/issues"
   },


### PR DESCRIPTION
added `package.json` to make npm instablle(easier)
~~~sh
npm install --save yatt/jquery.base64#v0.0.1
~~~

- License: MIT
- version: v0.0.1 (needs add release like https://github.com/tamakiii/jquery.base64/releases/tag/v0.0.1)